### PR TITLE
Fix CAPABILITY_RESPONSE, PIN_STATE_RESPONSE, ANALOG_MAPPING_RESPONSE

### DIFF
--- a/Adafruit_BLE_Firmata.h
+++ b/Adafruit_BLE_Firmata.h
@@ -126,7 +126,10 @@ public:
 	void sendDigitalPort(byte portNumber, int portData);
     void sendString(const char* string);
     void sendString(byte command, const char* string);
-	void sendSysex(byte command, byte bytec, byte* bytev);
+    void sendSysex(byte command, byte bytec, byte* bytev);
+    void sendSysexStart(byte command);
+    void sendSysexData(byte byteval);
+    void sendSysexEnd(void);
 /* attach & detach callback functions to messages */
     void attach(byte command, callbackFunction newFunction);
     void attach(byte command, systemResetCallbackFunction newFunction);
@@ -156,14 +159,18 @@ private:
     systemResetCallbackFunction currentSystemResetCallback;
     stringCallbackFunction currentStringCallback;
     sysexCallbackFunction currentSysexCallback;
+    uint8_t bufferedWrite[ACI_PIPE_TX_DATA_MAX_LEN];
+    byte bufWriteCount;
 
 /* private methods ------------------------------ */
     void processSysexMessage(void);
 	void systemReset(void);
     void pin13strobe(int count, int onInterval, int offInterval);
     void sendValueAsTwo7bitBytes(int value);
-    void startSysex(void);
+    void startSysex(byte command);
     void endSysex(void);
+    void bufferedBLEWrite(uint8_t b);
+    void bufferedBLEWrite(void);
 };
 
 extern Adafruit_BLE_FirmataClass BLE_Firmata;

--- a/Boards.h
+++ b/Boards.h
@@ -132,7 +132,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
 #if defined(NUM_ANALOG_INPUTS) && NUM_ANALOG_INPUTS == 6
 #define TOTAL_ANALOG_PINS       6
-#define TOTAL_PINS              22 // 14 digital (not all are 'digital/available') + 6 analog
+#define TOTAL_PINS              20 // 14 digital (not all are 'digital/available') + 6 analog
 #else
 #define TOTAL_ANALOG_PINS       8
 #define TOTAL_PINS              22 // 14 digital + 8 analog
@@ -142,7 +142,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 // we dont use digital 2 or 9, 10, 11, 12, 13 -> BTLE link
 #define IS_PIN_DIGITAL(p)       (((p) >= 3 && (p) <= 8) || ((p) >= 14  && (p) <= 19 ))
 #define IS_PIN_ANALOG(p)        ((p) >= 14 && (p) < 14 + TOTAL_ANALOG_PINS)
-#define IS_PIN_PWM(p)           digitalPinHasPWM(p)
+#define IS_PIN_PWM(p)           ((p) == 3 || (p) == 5 || (p) == 6)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) - 2 < MAX_SERVOS)
 #define IS_PIN_I2C(p)           ((p) == 18 || (p) == 19)
 #define PIN_TO_DIGITAL(p)       (p)

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -354,7 +354,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
   byte slaveRegister;
   byte data;
   unsigned int delayTime; 
-  
+
   switch(command) {
   case I2C_REQUEST:
     mode = argv[1] & I2C_READ_WRITE_MODE_MASK;
@@ -482,57 +482,56 @@ void sysexCallback(byte command, byte argc, byte *argv)
     }
     break;
   case CAPABILITY_QUERY:
-    Serial.write(START_SYSEX);
-    Serial.write(CAPABILITY_RESPONSE);
+    Serial.println(F("cap response"));
+    BLE_Firmata.sendSysexStart(CAPABILITY_RESPONSE);
     for (byte pin=0; pin < TOTAL_PINS; pin++) {
       if (IS_PIN_DIGITAL(pin)) {
-        Serial.write((byte)INPUT);
-        Serial.write(1);
-        Serial.write((byte)OUTPUT);
-        Serial.write(1);
+        BLE_Firmata.sendSysexData((byte)INPUT);
+        BLE_Firmata.sendSysexData(1);
+        BLE_Firmata.sendSysexData((byte)OUTPUT);
+        BLE_Firmata.sendSysexData(1);
       }
       if (IS_PIN_ANALOG(pin)) {
-        Serial.write(ANALOG);
-        Serial.write(10);
+        BLE_Firmata.sendSysexData(ANALOG);
+        BLE_Firmata.sendSysexData(10);
       }
       if (IS_PIN_PWM(pin)) {
-        Serial.write(PWM);
-        Serial.write(8);
+        BLE_Firmata.sendSysexData(PWM);
+        BLE_Firmata.sendSysexData(8);
       }
       if (IS_PIN_SERVO(pin)) {
-        Serial.write(SERVO);
-        Serial.write(14);
+        BLE_Firmata.sendSysexData(SERVO);
+        BLE_Firmata.sendSysexData(14);
       }
       if (IS_PIN_I2C(pin)) {
-        Serial.write(I2C);
-        Serial.write(1);  // to do: determine appropriate value 
+        BLE_Firmata.sendSysexData(I2C);
+        BLE_Firmata.sendSysexData(1);  // to do: determine appropriate value
       }
-      Serial.write(127);
+      BLE_Firmata.sendSysexData(127);
     }
-    Serial.write(END_SYSEX);
+    BLE_Firmata.sendSysexEnd();
     break;
   case PIN_STATE_QUERY:
+    Serial.println(F("state query"));
     if (argc > 0) {
       byte pin=argv[0];
-      Serial.write(START_SYSEX);
-      Serial.write(PIN_STATE_RESPONSE);
-      Serial.write(pin);
+      BLE_Firmata.sendSysexStart(PIN_STATE_RESPONSE);
+      BLE_Firmata.sendSysexData(pin);
       if (pin < TOTAL_PINS) {
-        Serial.write((byte)pinConfig[pin]);
-	Serial.write((byte)pinState[pin] & 0x7F);
-	if (pinState[pin] & 0xFF80) Serial.write((byte)(pinState[pin] >> 7) & 0x7F);
-	if (pinState[pin] & 0xC000) Serial.write((byte)(pinState[pin] >> 14) & 0x7F);
+        BLE_Firmata.sendSysexData((byte)pinConfig[pin]);
+        BLE_Firmata.sendSysexData((byte)pinState[pin] & 0x7F);
+        if (pinState[pin] & 0xFF80) BLE_Firmata.sendSysexData((byte)(pinState[pin] >> 7) & 0x7F);
+        if (pinState[pin] & 0xC000) BLE_Firmata.sendSysexData((byte)(pinState[pin] >> 14) & 0x7F);
       }
-      Serial.write(END_SYSEX);
+      BLE_Firmata.sendSysexEnd();
     }
     break;
   case ANALOG_MAPPING_QUERY:
-    Serial.write(START_SYSEX);
-    Serial.write(ANALOG_MAPPING_RESPONSE);
+    BLE_Firmata.sendSysexStart(ANALOG_MAPPING_RESPONSE);
     for (byte pin=0; pin < TOTAL_PINS; pin++) {
-      Serial.write(IS_PIN_ANALOG(pin) ? PIN_TO_ANALOG(pin) : 127);
+      BLE_Firmata.sendSysexData(IS_PIN_ANALOG(pin) ? PIN_TO_ANALOG(pin) : 127);
     }
-    Serial.write(END_SYSEX);
+    BLE_Firmata.sendSysexEnd();
     break;
   }
 }
@@ -621,7 +620,7 @@ void setup()
 
 void firmataInit() {
   Serial.println(F("Init firmata"));
-  //BLE_Firmata.setFirmwareVersion(FIRMATA_MAJOR_VERSION, FIRMATA_MINOR_VERSION);
+  BLE_Firmata.setFirmwareVersion(FIRMATA_MAJOR_VERSION, FIRMATA_MINOR_VERSION);
   //Serial.println(F("firmata analog"));
   BLE_Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);
   //Serial.println(F("firmata digital"));


### PR DESCRIPTION
The responses were being written to Serial instead of BLEserial. Buffered write to BLE serial added for SYSEX reponses since they are long. Excessive 1-byte writes results in ACI 91 errors.

The changes have been tested using node.js [firmata](https://www.npmjs.com/package/firmata) and [johnny-five](https://www.npmjs.com/package/johnny-five). The node.js [nRF8001](https://github.com/bbx10/node-nRF8001) driver is still pending a pull request so is not publicly available. I hope this will be resolved in the next few days.